### PR TITLE
Fix deprecation warnings about using URI.escape method

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ env:
   - RAILS_VERSION=3
   - RAILS_VERSION=4
   - RAILS_VERSION=5
+  - RAILS_VERSION=6
   - RAILS_VERSION=master
 
 rvm:
@@ -13,6 +14,9 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
+  - 2.6
+  - 2.7
   - ruby-head
 
 matrix:
@@ -20,12 +24,30 @@ matrix:
     - rvm: 1.9
       env: RAILS_VERSION=5
     - rvm: 1.9
+      env: RAILS_VERSION=6
+    - rvm: 1.9
       env: RAILS_VERSION=master
     - rvm: 2.0
       env: RAILS_VERSION=5
+    - rvm: 2.0
+      env: RAILS_VERSION=6
     - rvm: 2.0
       env: RAILS_VERSION=master
     - rvm: 2.1
       env: RAILS_VERSION=5
     - rvm: 2.1
+      env: RAILS_VERSION=6
+    - rvm: 2.1
+      env: RAILS_VERSION=master
+    - rvm: 2.2
+      env: RAILS_VERSION=6
+    - rvm: 2.2
+      env: RAILS_VERSION=master
+    - rvm: 2.3
+      env: RAILS_VERSION=6
+    - rvm: 2.3
+      env: RAILS_VERSION=master
+    - rvm: 2.4
+      env: RAILS_VERSION=6
+    - rvm: 2.4
       env: RAILS_VERSION=master

--- a/lib/gravatar_image_tag.rb
+++ b/lib/gravatar_image_tag.rb
@@ -112,13 +112,8 @@ module GravatarImageTag
 
     def self.url_params(gravatar_params)
       return nil if gravatar_params.keys.size == 0
-      array = gravatar_params.map { |k, v| "#{k}=#{value_cleaner(v)}" }
+      array = gravatar_params.map { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }
       "?#{array.join('&')}"
-    end
-
-    def self.value_cleaner(value)
-      value = value.to_s
-      URI.escape(value, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
     end
 
 end

--- a/spec/gravatar_image_tag_spec.rb
+++ b/spec/gravatar_image_tag_spec.rb
@@ -145,6 +145,10 @@ describe GravatarImageTag do
       expect(!!view.gravatar_image_url(email, secure: true).match("^https:\/\/secure.gravatar.com\/avatar\/")).to be_truthy
     end
 
+    it 'expect not to issue any deprecation warnings ' do
+     expect { view.gravatar_image_url(email, secure: true, rating: 'pg') }.not_to output.to_stderr
+    end
+
   end
 
 end

--- a/spec/gravatar_image_tag_spec.rb
+++ b/spec/gravatar_image_tag_spec.rb
@@ -17,7 +17,7 @@ describe GravatarImageTag do
   other_image_escaped   = 'http%3A%2F%2Fmdeering.com%2Fimages%2Fother_gravatar.png'
   secure                = false
 
-  view = ActionView::Base.new
+  let(:view) { ActionView::Base.new(ActionView::LookupContext.new([])) }
 
   context '#gravatar_image_tag' do
 
@@ -29,7 +29,6 @@ describe GravatarImageTag do
       { gravatar_id: md5, default: other_image_escaped, size: 30 } => { gravatar: { default: other_image, size: 30 } }
     }.each do |params, options|
       it "#gravatar_image_tag should create the provided url with the provided options #{options}" do
-        view = ActionView::Base.new
         image_tag = view.gravatar_image_tag(email, options)
         expect(image_tag.include?("#{params.delete(:gravatar_id)}")).to be_truthy
         expect(params.all? {|key, value| image_tag.include?("#{key}=#{value}")}).to be_truthy
@@ -62,7 +61,6 @@ describe GravatarImageTag do
       { gravatar_id: md5, size: 30, default: other_image_escaped } => { gravatar: { default: other_image, size: 30 } },
     }.each do |params, options|
       it "#gravatar_image_tag #{params} should create the provided url when defaults have been set with the provided options #{options}"  do
-        view = ActionView::Base.new
         image_tag = view.gravatar_image_tag(email, options)
         expect(image_tag.include?("#{params.delete(:gravatar_id)}.#{default_filetype}")).to be_truthy
         expect(params.all? {|key, value| image_tag.include?("#{key}=#{value}")}).to be_truthy


### PR DESCRIPTION
 - [x] Replace obsolete URI.escape method with CGI.escape (no specs failed so it should be fine, I think)
 - [x] Fix deprecation warnings about using ActionView::Base.new in specs
 - [x] Include newer Rails and Ruby versions into CI matrix 