### PR TITLE
Move to URI parser api to eliminate obsolesence warning from logs.

### DIFF
--- a/lib/gravatar_image_tag.rb
+++ b/lib/gravatar_image_tag.rb
@@ -118,7 +118,8 @@ module GravatarImageTag
 
     def self.value_cleaner(value)
       value = value.to_s
-      URI.escape(value, Regexp.new("[^#{URI::PATTERN::UNRESERVED}]"))
+      parser = URI::Parser.new(:UNRESERVED => URI::REGEXP::PATTERN::UNRESERVED)
+      parser.escape(value)
     end
 
 end


### PR DESCRIPTION
Proposed change to get rid of excessive log file noise when on Ruby 2.7+.